### PR TITLE
Add Meshtastic TCP host/port config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The bridge requires a `config.ini` file in the project's root directory.
 2.  **Edit `config.ini`:**
     Open the newly created `config.ini` file in a text editor and adjust the settings according to your hardware setup:
     * `MESHTASTIC_SERIAL_PORT`: Set the correct serial port for your Meshtastic device (e.g., `/dev/ttyUSB0`, `COM3`). Use `meshtastic --port list` to help find it.
+    * `MESHTASTIC_TCP_HOST`/`MESHTASTIC_TCP_PORT`: Host and port if connecting to a Meshtastic daemon over TCP instead of serial. Defaults are `127.0.0.1:4403`.
     * `MESHCORE_SERIAL_PORT`: Set the correct serial port for your MeshCore device (e.g., `/dev/ttyS0`, `COM4`).
     * `MESHCORE_BAUD_RATE`: **Crucially, set this to match the baud rate configured on your MeshCore device.** (e.g., `9600`, `115200`).
     * `MESHCORE_PROTOCOL`: Select the protocol handler matching how your MeshCore device communicates. `json_newline` is the default. See `docs/architecture.md` for the expected JSON structure if using the default.

--- a/ammb/config_handler.py
+++ b/ammb/config_handler.py
@@ -12,6 +12,8 @@ from typing import NamedTuple, Optional
 class BridgeConfig(NamedTuple):
     """Stores all configuration settings for the bridge."""
     meshtastic_port: str
+    meshtastic_tcp_host: str
+    meshtastic_tcp_port: int
     meshcore_port: str
     meshcore_baud: int
     meshcore_protocol: str
@@ -27,6 +29,8 @@ CONFIG_FILE = "config.ini" # Default config filename
 DEFAULT_CONFIG = {
     'MESHTASTIC_SERIAL_PORT': '/dev/ttyUSB0', # Example for Linux
     # 'MESHTASTIC_SERIAL_PORT': 'COM3',      # Example for Windows
+    'MESHTASTIC_TCP_HOST': '127.0.0.1',       # Default host for TCP connection
+    'MESHTASTIC_TCP_PORT': '4403',            # Default port for TCP connection
     'MESHCORE_SERIAL_PORT': '/dev/ttyS0',    # Example for Linux
     # 'MESHCORE_SERIAL_PORT': 'COM4',        # Example for Windows
     'MESHCORE_BAUD_RATE': '9600',            # Common baud rate, adjust as needed
@@ -69,7 +73,7 @@ def load_config(config_path: str = CONFIG_FILE) -> Optional[BridgeConfig]:
         config.read(config_path)
 
         # Use the [DEFAULT] section for all settings
-        if 'DEFAULT' not in config:
+        if not config.defaults():
              logger.error(f"Configuration file '{config_path}' is missing the required [DEFAULT] section.")
              return None
         cfg_section = config['DEFAULT']
@@ -80,6 +84,8 @@ def load_config(config_path: str = CONFIG_FILE) -> Optional[BridgeConfig]:
             return cfg_section.get(key, DEFAULT_CONFIG[key])
 
         meshtastic_port = get_setting('MESHTASTIC_SERIAL_PORT')
+        meshtastic_tcp_host = get_setting('MESHTASTIC_TCP_HOST')
+        meshtastic_tcp_port_str = get_setting('MESHTASTIC_TCP_PORT')
         meshcore_port = get_setting('MESHCORE_SERIAL_PORT')
         meshcore_network_id = get_setting('MESHCORE_NETWORK_ID')
         bridge_node_id = get_setting('BRIDGE_NODE_ID')
@@ -88,6 +94,9 @@ def load_config(config_path: str = CONFIG_FILE) -> Optional[BridgeConfig]:
         try:
             meshcore_baud = int(get_setting('MESHCORE_BAUD_RATE'))
             queue_size = int(get_setting('MESSAGE_QUEUE_SIZE'))
+            meshtastic_tcp_port = int(meshtastic_tcp_port_str)
+            if meshtastic_tcp_port <= 0 or meshtastic_tcp_port > 65535:
+                raise ValueError('MESHTASTIC_TCP_PORT must be between 1 and 65535')
             if meshcore_baud <= 0 or queue_size <= 0:
                  raise ValueError("Baud rate and queue size must be positive integers.")
         except ValueError as e:
@@ -116,6 +125,8 @@ def load_config(config_path: str = CONFIG_FILE) -> Optional[BridgeConfig]:
         # --- Create and Return Config Object ---
         bridge_config = BridgeConfig(
             meshtastic_port=meshtastic_port,
+            meshtastic_tcp_host=meshtastic_tcp_host,
+            meshtastic_tcp_port=meshtastic_tcp_port,
             meshcore_port=meshcore_port,
             meshcore_baud=meshcore_baud,
             meshcore_protocol=meshcore_protocol,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,16 @@ All settings are currently placed under the `[DEFAULT]` section.
         * Check your operating system's device manager or `/dev` directory.
     * **Required:** Yes
 
+* **`MESHTASTIC_TCP_HOST`**
+    * **Description:** Hostname or IP address for connecting to a Meshtastic daemon over TCP.
+    * **Default:** `127.0.0.1`
+    * **Required:** No
+
+* **`MESHTASTIC_TCP_PORT`**
+    * **Description:** TCP port for the Meshtastic daemon connection.
+    * **Default:** `4403`
+    * **Required:** No
+
 ### Meshcore Settings
 
 * **`MESHCORE_SERIAL_PORT`**

--- a/examples/config.ini.example
+++ b/examples/config.ini.example
@@ -12,6 +12,12 @@
 # Example Windows: COM3
 MESHTASTIC_SERIAL_PORT = /dev/ttyUSB0
 
+# Host and port for TCP connection to Meshtastic (optional).
+# Used if connecting over TCP instead of serial.
+# Host is typically the IP address of the device running meshtasticd.
+MESHTASTIC_TCP_HOST = 127.0.0.1
+MESHTASTIC_TCP_PORT = 4403
+
 
 # --- Meshcore Settings ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ def temp_config_file(tmp_path) -> Generator[str, None, None]:
     parser = configparser.ConfigParser()
     parser['DEFAULT'] = {
         'MESHTASTIC_SERIAL_PORT': '/dev/test_meshtastic',
+        'MESHTASTIC_TCP_HOST': '192.168.1.1',
+        'MESHTASTIC_TCP_PORT': '4403',
         'MESHCORE_SERIAL_PORT': '/dev/test_meshcore',
         'MESHCORE_BAUD_RATE': '19200',
         'MESHCORE_PROTOCOL': 'json_newline',

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -17,6 +17,8 @@ def test_load_config_success(temp_config_file):
     assert isinstance(config, BridgeConfig)
     # Check if values match the ones written in the fixture
     assert config.meshtastic_port == '/dev/test_meshtastic'
+    assert config.meshtastic_tcp_host == '192.168.1.1'
+    assert config.meshtastic_tcp_port == 4403
     assert config.meshcore_port == '/dev/test_meshcore'
     assert config.meshcore_baud == 19200
     assert config.meshcore_protocol == 'json_newline'
@@ -78,6 +80,8 @@ def test_load_config_uses_defaults(tmp_path):
     assert config.meshtastic_port == '/dev/partial_meshtastic' # Overridden
     assert config.log_level == 'WARNING' # Overridden
     # Check a default value
+    assert config.meshtastic_tcp_host == DEFAULT_CONFIG['MESHTASTIC_TCP_HOST']
+    assert config.meshtastic_tcp_port == int(DEFAULT_CONFIG['MESHTASTIC_TCP_PORT'])
     assert config.meshcore_port == DEFAULT_CONFIG['MESHCORE_SERIAL_PORT']
     assert config.meshcore_baud == int(DEFAULT_CONFIG['MESHCORE_BAUD_RATE'])
     assert config.meshcore_protocol == DEFAULT_CONFIG['MESHCORE_PROTOCOL']


### PR DESCRIPTION
## Summary
- extend config defaults with MESHTASTIC_TCP_HOST and MESHTASTIC_TCP_PORT
- document new options in README and docs
- update example config file
- support new options in config handler and tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68870a14090c832d8e45072bf99a5644