### PR TITLE
Update dependency check for TCP interface

### DIFF
--- a/run_bridge.py
+++ b/run_bridge.py
@@ -31,7 +31,7 @@ try:
     import serial
     from pubsub import pub
     import meshtastic
-    import meshtastic.serial_interface # Explicitly check submodule too
+    import meshtastic.tcp_interface  # Explicitly check submodule too
 except ImportError as e:
     # Use basic print/logging as full logging isn't set up yet
     print(f"ERROR: Missing required library - {e.name}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- support `meshtastic.tcp_interface` in dependency check
- drop `meshtastic.serial_interface` import

## Testing
- `flake8 ammb/ tests/ run_bridge.py`
- `mypy ammb/ run_bridge.py` *(fails: missing type stubs)*
- `pytest -q` *(fails: test_load_config_missing_section)*

------
https://chatgpt.com/codex/tasks/task_b_68870a1b9934832d9ef2fa30184948a7