### PR TITLE
Fix config loader variable names

### DIFF
--- a/ammb/config_handler.py
+++ b/ammb/config_handler.py
@@ -84,14 +84,9 @@ def load_config(config_path: str = CONFIG_FILE) -> Optional[BridgeConfig]:
         def get_setting(key: str) -> str:
             return cfg_section.get(key, DEFAULT_CONFIG[key])
 
+        meshtastic_port = get_setting('MESHTASTIC_SERIAL_PORT')
         meshtastic_tcp_host = get_setting('MESHTASTIC_TCP_HOST')
-        try:
-            meshtastic_tcp_port = int(get_setting('MESHTASTIC_TCP_PORT'))
-            if meshtastic_tcp_port <= 0:
-                raise ValueError("TCP port must be a positive integer.")
-        except ValueError as e:
-            logger.error(f"Invalid MESHTASTIC_TCP_PORT: {e}")
-            return None
+        meshtastic_tcp_port_str = get_setting('MESHTASTIC_TCP_PORT')
         meshcore_port = get_setting('MESHCORE_SERIAL_PORT')
         meshcore_network_id = get_setting('MESHCORE_NETWORK_ID')
         bridge_node_id = get_setting('BRIDGE_NODE_ID')


### PR DESCRIPTION
## Summary
- restore `meshtastic_port` and `meshtastic_tcp_port_str` variables in `config_handler`
- ensure TCP port is validated from the string value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68871263e1d0832db602faf60dc12141