### PR TITLE
Implement CompanionFrameProtocol for MeshCore binary frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The bridge requires a `config.ini` file in the project's root directory.
     Open the newly created `config.ini` file in a text editor and adjust the settings according to your hardware setup:
     * `MESHCORE_SERIAL_PORT`: Set the correct serial port for your MeshCore device (e.g., `/dev/ttyS0`, `COM4`).
     * `MESHCORE_BAUD_RATE`: **Crucially, set this to match the baud rate configured on your MeshCore device.** (e.g., `9600`, `115200`).
-    * `MESHCORE_PROTOCOL`: Select the protocol handler matching how your MeshCore device communicates. `json_newline` is the default. See `docs/architecture.md` for the expected JSON structure if using the default.
+    * `MESHCORE_PROTOCOL`: Select the protocol handler matching how your MeshCore device communicates. `json_newline` is the default. Set to `companion_frame` for the binary companion-radio frames defined in the MeshCore wiki.
     * `BRIDGE_NODE_ID`: **Recommended:** Set this to the actual Meshtastic Node ID (e.g., `!a1b2c3d4`) of the device running the bridge to prevent message loops. Use `meshtastic --info` to find your ID.
     * `LOG_LEVEL`: Adjust logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). `INFO` is a good starting point.
 

--- a/ammb/config_handler.py
+++ b/ammb/config_handler.py
@@ -43,7 +43,7 @@ DEFAULT_CONFIG = {
 
 # Valid options for settings requiring specific choices
 VALID_LOG_LEVELS = {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'}
-VALID_MESHCORE_PROTOCOLS = {'json_newline'} # Add more as they are implemented
+VALID_MESHCORE_PROTOCOLS = {'json_newline', 'companion_frame'}
 
 # --- Functions ---
 def load_config(config_path: str = CONFIG_FILE) -> Optional[BridgeConfig]:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ All settings are currently placed under the `[DEFAULT]` section.
     * **Description:** Specifies how messages are formatted when sent and received over the MeshCore serial connection.
     * **Supported Values:**
         * `json_newline`: Messages are expected to be single lines of UTF-8 encoded JSON text, terminated by a newline character (`\n`). This is the default and recommended protocol for structured data exchange. See `docs/architecture.md` for the expected JSON structure.
+        * `companion_frame`: Binary companion-radio frames as defined in the MeshCore wiki.
         * *(Future protocols like `plain_text` could be added)*
     * **Default:** `json_newline`
     * **Required:** Yes (effectively, as the default is used if missing)

--- a/examples/config.ini.example
+++ b/examples/config.ini.example
@@ -37,6 +37,7 @@ MESHCORE_BAUD_RATE = 9600
 # Built-in options:
 #   json_newline: Expects/sends newline-terminated UTF-8 encoded JSON strings.
 #                 See docs/architecture.md for the expected JSON structure.
+#   companion_frame: Binary companion-radio frames as defined in MeshCore wiki.
 # You can add custom protocols in ammb/protocol.py if needed.
 MESHCORE_PROTOCOL = json_newline
 


### PR DESCRIPTION
## Summary
- add `CompanionFrameProtocol` to decode MeshCore binary frames
- support the new protocol in config handling and documentation
- update example configuration and README with new protocol details
- adjust receiver loop to read frame-based data
- extend protocol tests for the new handler

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68886453c220832dae2a4ed8c9a8d527